### PR TITLE
Update ngrok link to official guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every incoming request is routed to a "listener". Inside this directory, we grou
 
 Only implement OAuth if you plan to distribute your application across multiple workspaces. A separate `app-oauth.js` file can be found with relevant OAuth settings.
 
-When using OAuth, Slack requires a public URL where it can send requests. In this template app, we've used [`ngrok`](https://ngrok.com/download). Checkout [this guide](https://api.slack.com/tutorials/tunneling-with-ngrok) for setting it up.
+When using OAuth, Slack requires a public URL where it can send requests. In this template app, we've used [`ngrok`](https://ngrok.com/download). Checkout [this guide](https://ngrok.com/docs#getting-started-expose) for setting it up.
 
 Start `ngrok` to access the app on an external network and create a redirect URL for OAuth. 
 


### PR DESCRIPTION
Fixes #2.

Documentation around `ngrok` was removed at some point from the API website. As such, the new link points to the official `ngrok` [getting started guide](https://ngrok.com/docs#getting-started-expose).