### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
-    allow:
-      - dependency-name: "@slack/bolt"

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   },
   "dependencies": {
     "@slack/bolt": "^3.8.1",
-    "dotenv": "^10.0.0"
+    "dotenv": "~10.0.0"
   },
   "devDependencies": {
-    "eslint": "^8.8.0",
-    "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-import": "^2.25.4"
+    "eslint": "~8.8.0",
+    "eslint-config-airbnb-base": "~15.0.0",
+    "eslint-plugin-import": "~2.25.4"
   }
 }


### PR DESCRIPTION
This pull request adds the configuration for Dependabot, limiting updates to the `@slack/bolt` package.