### PR TITLE
Added a create new script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,36 @@ This is a generic Bolt for JavaScript template app used to build out Slack apps.
 Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
 ## Installation
 
-#### Create a Slack App
+### Start a new project
+You have two options:
+
+1. Clone this [repo template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) by clicking the green **Use this template** button at the top of this page. Now you can clone the new repo you just created.
+
+2. Run the following script in your CLI to create a new app locally:
+
+```
+curl -fsSL https:// ... | bash the-next-great-slack-app
+```
+
+### Create a Slack App
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
 2. Choose the workspace you want to install the application to
 3. Copy the contents of [manifest.json](./manifest.json) into the text box that says `*Paste your manifest code here*` (within the JSON tab) and click *Next*
 4. Review the configuration and click *Create*
 5. Click *Install to Workspace* and *Allow* on the screen that follows. You'll then be redirected to the App Configuration dashboard.
 
-#### Environment Variables
+### Environment Variables
 Before you can run the app, you'll need to store some environment variables.
 
 1. Copy `.env.sample` to `.env`
 2. Open your apps configuration page from [this list](https://api.slack.com/apps), click *OAuth & Permissions* in the left hand menu, then copy the *Bot User OAuth Token* into your `.env` file under `SLACK_BOT_TOKEN`
 3. Click *Basic Information* from the left hand menu and follow the steps in the *App-Level Tokens* section to create an app-level token with the `connections:write` scope. Copy that token into your `.env` as `SLACK_APP_TOKEN`.
 
-#### Install Dependencies
+### Install Dependencies
 
 `npm install`
 
-#### Run Bolt Server
+### Run Bolt Server
 
 `npm start`
 

--- a/scripts/new-bolt-project.sh
+++ b/scripts/new-bolt-project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+new_proj_dir="my-slack-app"
+repo="https://github.com/slack-samples/bolt-js-starter-template/archive/main.zip"
+
+if [ $# -gt 0 ]; then
+  new_proj_dir=${1}
+fi
+
+mkdir -p "$new_proj_dir"
+
+echo "\nDownloading the project template"
+curl --show-error --location "$repo" | tar -xf - -C "$new_proj_dir" --strip-components=1


### PR DESCRIPTION
I'm not actually sure if this is better than just cloning the repo as a template but wanted to test out the idea.

There's a new script in `scripts/new-bolt-project.sh` that lets a user do something like 

```
curl -fsSL https://raw.githubusercontent.com/slack-samples/bolt-js-starter-template/main/scripts/new-bolt-project.sh | bash
```

and it would create a new bolt app on their local. It basically skips the step of cloning a repo from gh template and then downloading it. 