### PR TITLE
Adding .slack/apps.dev.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 .DS_Store
 .env*
+.slack/apps.dev.json


### PR DESCRIPTION
dev-versions of apps will be stored in this file, which is unique per dev, which should not be checked into version control.

Related to changes in CLI: 
https://github.com/slackapi/slack-cli/pull/521/