### PR TITLE
fix: await chat.postmessage to catch api error responses

### DIFF
--- a/listeners/views/sample-view.js
+++ b/listeners/views/sample-view.js
@@ -6,7 +6,7 @@ const sampleViewCallback = async ({ ack, view, body, client }) => {
     const sampleInputValue = formValues.input_block_id.sample_input_id.value;
     const sampleConvoDropdown = formValues.select_channel_block_id.sample_dropdown_id;
 
-    client.chat.postMessage({
+    await client.chat.postMessage({
       channel: sampleConvoDropdown.selected_conversation,
       text: `<@${body.user.id}> submitted the following :sparkles: hopes and dreams :sparkles:: \n\n ${sampleInputValue}`,
     });


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### Summary

This PR awaits the response from `chat.postMessage` in the `views` handler to catch errors returned in the API response and avoid an exit. Matches https://github.com/slack-samples/bolt-ts-starter-template/pull/139 👾 

### Preview

#### Before changes

```
Error: An API error occurred: not_in_channel
...

Node.js v22.11.0
Local run exited with code 1
```

#### After changes

```
[ERROR]  bolt-app Error: An API error occurred: not_in_channel
...
```

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
