### PR TITLE
feat: add slack api url to app constructor

### DIFF
--- a/app-oauth.js
+++ b/app-oauth.js
@@ -19,6 +19,9 @@ const app = new App({
     // without rendering the web page with "Add to Slack" button
     directInstall: false,
   },
+  clientOptions: {
+    slackApiUrl: process.env.SLACK_API_URL,
+  },
 });
 
 /** Register Listeners */

--- a/app.js
+++ b/app.js
@@ -10,6 +10,9 @@ const app = new App({
   socketMode: true,
   appToken: process.env.SLACK_APP_TOKEN,
   logLevel: LogLevel.DEBUG,
+  clientOptions: {
+    slackApiUrl: process.env.SLACK_API_URL,
+  },
 });
 
 /** Register Listeners */


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] New feature

### Summary

This pull request adds support for configuring a custom Slack API URL via the `SLACK_API_URL` environment variable, passed to the App constructor through `clientOptions.slackApiUrl`. This enables testing against non-production API endpoints.

### Slack CLI

Create a new app from this branch:

```
slack create my-app -t slack-samples/bolt-js-starter-template -b zimeg-feat-api-url
```

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)