### PR TITLE
docs: add Slack CLI setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,7 @@ slack create my-bolt-js-app --template slack-samples/bolt-js-starter-template
 cd my-bolt-js-app
 ```
 
-#### Creating the Slack app
-
-Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
-
-```sh
-slack install
-```
-
-After the Slack app has been created you're all set to start developing!
+After cloning, you're all set to start developing!
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a generic Bolt for JavaScript template app used to build out Slack apps.
 
 ## Setup
 
-Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don’t have one setup, go ahead and [create one](https://slack.com/create).
+Before getting started, make sure you have a development workspace where you have permissions to install apps. If you don't have one setup, go ahead and [create one](https://slack.com/create).
 
 ### Developer Program
 
@@ -12,7 +12,41 @@ Join the [Slack Developer Program](https://api.slack.com/developer-program) for 
 
 ## Installation
 
-#### Create a Slack App
+<details><summary><strong>Using Slack CLI</strong></summary>
+
+Install the latest version of the Slack CLI for your operating system:
+
+- [Slack CLI for macOS & Linux](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux/)
+- [Slack CLI for Windows](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows/)
+
+You'll also need to log in if this is your first time using the Slack CLI.
+
+```sh
+slack login
+```
+
+#### Initializing the project
+
+```sh
+slack create my-bolt-js-app --template slack-samples/bolt-js-starter-template
+cd my-bolt-js-app
+```
+
+#### Creating the Slack app
+
+Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
+
+```sh
+slack install
+```
+
+After the Slack app has been created you're all set to start developing!
+
+</details>
+
+<details><summary><strong>Using Terminal</strong></summary>
+
+#### Create Your Slack App
 
 1. Open [https://api.slack.com/apps/new](https://api.slack.com/apps/new) and choose "From an app manifest"
 2. Choose the workspace you want to install the application to
@@ -28,33 +62,45 @@ Before you can run the app, you'll need to store some environment variables.
 2. Open your apps configuration page from [this list](https://api.slack.com/apps), click _OAuth & Permissions_ in the left hand menu, then copy the _Bot User OAuth Token_ into your `.env` file under `SLACK_BOT_TOKEN`
 3. Click _Basic Information_ from the left hand menu and follow the steps in the _App-Level Tokens_ section to create an app-level token with the `connections:write` scope. Copy that token into your `.env` as `SLACK_APP_TOKEN`.
 
-### Setup Your Local Project
+#### Initializing the project
 
-```zsh
-# Clone this project onto your machine
-git clone https://github.com/slack-samples/bolt-js-starter-template.git
+```sh
+git clone https://github.com/slack-samples/bolt-js-starter-template.git my-bolt-js-app
+cd my-bolt-js-app
+```
 
-# Change into this project directory
-cd bolt-js-starter-template
+#### Install dependencies
 
-# Install dependencies
+```sh
 npm install
+```
 
-# Run a Bolt server that restarts after file changes
-npm run dev
+</details>
 
-# Run a Bolt server
+## Development
+
+### Starting the app
+
+#### Slack CLI
+
+```sh
+slack run
+```
+
+#### Terminal
+
+```sh
 npm start
 ```
 
-#### Linting
+### Linting
 
 ```zsh
 # Run lint for code formatting and linting
 npm run lint
 ```
 
-#### Testing
+### Testing
 
 ```zsh
 # Run test for unit tests
@@ -73,7 +119,7 @@ npm test
 
 ### `/listeners`
 
-Every incoming request is routed to a "listener". Inside this directory, we group each listener based on the Slack Platform feature used, so `/listeners/shortcuts` handles incoming [Shortcuts](https://api.slack.com/interactivity/shortcuts) requests, `/listeners/views` handles [View submissions](https://api.slack.com/reference/interaction-payloads/views#view_submission) and so on.
+Every incoming request is routed to a "listener". Inside this directory, we group each listener based on the Slack Platform feature used, so `/listeners/shortcuts` handles incoming [Shortcuts](https://docs.slack.dev/interactivity/implementing-shortcuts/) requests, `/listeners/views` handles [View submissions](https://api.slack.com/reference/interaction-payloads/views#view_submission) and so on.
 
 ## App Distribution / OAuth
 


### PR DESCRIPTION
## Summary

- Adds collapsible "Using Slack CLI" section with install, login, create, and install commands
- Wraps existing manual setup in a collapsible "Using Terminal" section
- Adds a Development section with `slack run` and `npm start` options
- Matches the pattern used by `bolt-js-assistant-template` and `bolt-js-search-template`

## Test plan

- [ ] Verify rendered README displays both collapsible sections correctly
- [ ] Confirm CLI commands reference the correct template repo name